### PR TITLE
Fix broken link to embedded GM video.

### DIFF
--- a/how-to-evaluate-analytically.html
+++ b/how-to-evaluate-analytically.html
@@ -88,7 +88,7 @@
 		
 		<p class="embed-responsive embed-responsive-16by9">
 			<video width="480" height="320" controls="controls">
-				<source src="http://gendermag.org/GenderMag%20Demonstration.mp4" type="video/mp4">
+				<source src="http://gendermag.org/Videos/GenderMag%20Demonstration.mp4" type="video/mp4">
 			</video>
 		</p>
 		


### PR DESCRIPTION
The GenderMag website was updated in the last year with a new file structure, so the embedded video was broken. Fixed with updated URL. 